### PR TITLE
Board/feature/20 글 내용 조회 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,6 @@ close #n
 # 변경된 점
 -[x] haha
 
-# UML 클래스 다이어그램
+# 도메인 모델
+mermaid
 ```

--- a/board/src/main/java/jdbc/board/application/board/service/PostService.java
+++ b/board/src/main/java/jdbc/board/application/board/service/PostService.java
@@ -1,0 +1,18 @@
+package jdbc.board.application.board.service;
+
+import jdbc.board.domain.board.exception.PostNotFoundException;
+import jdbc.board.domain.board.model.Post;
+import jdbc.board.domain.board.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class PostService {
+    private final PostRepository postRepository;
+
+    public Post findPostDetails(Long postId) {
+        return postRepository.findById(postId).orElseThrow(() -> new PostNotFoundException("게시글을 찾을 수 없습니다."));
+    }
+}

--- a/board/src/main/java/jdbc/board/domain/board/exception/PostNotFoundException.java
+++ b/board/src/main/java/jdbc/board/domain/board/exception/PostNotFoundException.java
@@ -1,0 +1,7 @@
+package jdbc.board.domain.board.exception;
+
+public class PostNotFoundException extends RuntimeException {
+    public PostNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/board/src/main/java/jdbc/board/domain/board/model/Comment.java
+++ b/board/src/main/java/jdbc/board/domain/board/model/Comment.java
@@ -1,7 +1,9 @@
 package jdbc.board.domain.board.model;
 
 import jdbc.board.domain.board.exception.InvalidContentsException;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.util.Objects;
 
@@ -16,6 +18,13 @@ public class Comment {
         this.contents = contents;
         this.post = post;
     }
+
+    Comment(Long id, Post post, String contents) {
+        this.id = id;
+        this.post = post;
+        this.contents = contents;
+    }
+
 
     void changeContents(String contents) {
         validateContents(contents);

--- a/board/src/main/java/jdbc/board/domain/board/model/Post.java
+++ b/board/src/main/java/jdbc/board/domain/board/model/Post.java
@@ -44,6 +44,18 @@ public class Post {
         domainEvents.add(new CommentCreatedDomainEvent(comment));
     }
 
+    /**
+     * 외부 comment가 추가되더라도
+     * 실제 이벤트 퍼블리셔에 코멘트 생성 이벤트가 추가되진 않음
+     * 실제 영속성 데이터에 영향을 끼치진 않지만, 리포지토리에서 Post 애그리거트를 형성하기 위해 필요한 코드.
+     * @param commentId db에서 가져온 comment_id
+     * @param contents db에서 가져온 댓글의 내용
+     */
+    public void attachComment(Long commentId, String contents){
+        Comment comment = new Comment(commentId, this, contents);
+        comments.add(comment);
+    }
+
     public void changeCommentContents(Long commentId, String newContents) {
         Comment comment = comments.stream().filter(cmt -> cmt.getId().equals(commentId)).findFirst()
                 .orElseThrow(() -> new CommentNotFoundException("해당 댓글을 찾을 수 없습니다."));

--- a/board/src/main/java/jdbc/board/infrastructure/PostRepositoryJDBC.java
+++ b/board/src/main/java/jdbc/board/infrastructure/PostRepositoryJDBC.java
@@ -1,0 +1,68 @@
+package jdbc.board.infrastructure;
+
+import jdbc.board.domain.board.model.Post;
+import jdbc.board.domain.board.repository.PostRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Repository
+public class PostRepositoryJDBC implements PostRepository {
+    private final NamedParameterJdbcTemplate template;
+
+    @Override
+    public Optional<Post> findById(Long id) {
+        SqlParameterSource sqlParameterSource = new MapSqlParameterSource().addValue("id", id);
+        ResultSetExtractor<Post> postResultSetExtractor = getPostResultSetExtractor();
+        String sql = """
+                select
+                    post.*,
+                    comment.id as comment_id,
+                    comment.contents as comment_contents,
+                from post
+                left join comment on comment.post_id = post.id
+                where post.id = :id
+                """;
+        return Optional.ofNullable(template.query(sql, sqlParameterSource, postResultSetExtractor));
+    }
+
+    @Override
+    public Post save(Post post) {
+        return null;
+    }
+
+    @Override
+    public void deleteById(Long id) {
+
+    }
+
+    private static ResultSetExtractor<Post> getPostResultSetExtractor() {
+        return (rs) -> {
+            Post post = null;
+
+            while (rs.next()) {
+                if (post == null) {
+                    post = new Post(
+                            rs.getLong("id"),
+                            rs.getString("title"),
+                            rs.getString("contents")
+                    );
+                }
+                Long commentId = rs.getObject("comment_id", Long.class);
+                if(commentId != null) {
+                    String commentContent = rs.getString("comment_contents");
+                    post.attachComment(commentId, commentContent);
+                }
+            }
+            return post;
+        };
+    }
+
+
+}


### PR DESCRIPTION
# 관련 이슈
close #20 

# 변경된 점
-[x] Comment에 id 값을 표현하는 default 접근제어자 생성자 구현
-[x] Post에 attachComment 구현
-[x] PostRepositoryJDBC에 글 내용 조회 기능 구현
-[x] 게시글을 찾을 수 없을 시 사용하는 PostNotFoundException 구현
-[x] PostService의 조회 로직 구현

# 도메인 모델
```mermaid
classDiagram
    class post {
        -id: Long
        -title: String
        -contents: String
        +changeTitle(String title): void
        +changeContents(String contents): void
        +addComment(String commentContents): void
        +attachComment(Long commentId, String commentContents): void
        +updateCommentContents(Long commentId, String contents): void
        +removeComment(Long commentId): void
    }
    class comment{
        -id: Long
        -contents: String
        ~changeContents(String contents): void
    }
    
    post "1"--"*" comment
```