### PR TITLE
Board/feature/19 글 목록 조회 기능 구현

### DIFF
--- a/board/src/main/java/jdbc/board/application/board/dto/PostLine.java
+++ b/board/src/main/java/jdbc/board/application/board/dto/PostLine.java
@@ -1,0 +1,12 @@
+package jdbc.board.application.board.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PostLine {
+    private Long postId;
+    private String postTitle;
+    private Long commentCount;
+}

--- a/board/src/main/java/jdbc/board/application/board/repository/PostQueryRepository.java
+++ b/board/src/main/java/jdbc/board/application/board/repository/PostQueryRepository.java
@@ -1,0 +1,9 @@
+package jdbc.board.application.board.repository;
+
+import jdbc.board.application.board.dto.PostLine;
+
+import java.util.List;
+
+public interface PostQueryRepository {
+    List<PostLine> findAllPostLines(int page, int pageSize);
+}

--- a/board/src/main/java/jdbc/board/application/board/service/PostService.java
+++ b/board/src/main/java/jdbc/board/application/board/service/PostService.java
@@ -1,18 +1,27 @@
 package jdbc.board.application.board.service;
 
+import jdbc.board.application.board.dto.PostLine;
+import jdbc.board.application.board.repository.PostQueryRepository;
 import jdbc.board.domain.board.exception.PostNotFoundException;
 import jdbc.board.domain.board.model.Post;
 import jdbc.board.domain.board.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 
 @Service
 @RequiredArgsConstructor
 public class PostService {
     private final PostRepository postRepository;
+    private final PostQueryRepository postQueryRepository;
 
     public Post findPostDetails(Long postId) {
         return postRepository.findById(postId).orElseThrow(() -> new PostNotFoundException("게시글을 찾을 수 없습니다."));
+    }
+
+    public List<PostLine> findAllPostLines(int page, int pageSize) {
+        return postQueryRepository.findAllPostLines(page, pageSize);
     }
 }

--- a/board/src/main/java/jdbc/board/infrastructure/PostQueryRepositoryJDBC.java
+++ b/board/src/main/java/jdbc/board/infrastructure/PostQueryRepositoryJDBC.java
@@ -1,0 +1,45 @@
+package jdbc.board.infrastructure;
+
+import jdbc.board.application.board.dto.PostLine;
+import jdbc.board.application.board.repository.PostQueryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class PostQueryRepositoryJDBC implements PostQueryRepository {
+    private final NamedParameterJdbcTemplate template;
+
+    public List<PostLine> findAllPostLines(int page, int pageSize) {
+        String sql = """
+                SELECT
+                    p.id            AS post_id,
+                    p.title         AS post_title,
+                    COUNT(c.id)     AS comment_count
+                FROM
+                    post p
+                LEFT JOIN
+                    comment c
+                  ON p.id = c.post_id
+                GROUP BY
+                    p.id,
+                    p.title
+                ORDER BY p.id DESC
+                LIMIT :pageSize
+                OFFSET :startIndex
+                """;
+        RowMapper<PostLine> postLineRowMapper = new BeanPropertyRowMapper<>(PostLine.class);
+
+        return template.query(sql,
+                new MapSqlParameterSource()
+                        .addValue("pageSize", pageSize)
+                        .addValue("startIndex", page*pageSize),
+                postLineRowMapper);
+    }
+}


### PR DESCRIPTION
# 관련 이슈
close #19 

# 변경된 점
-[x] 게시글 제목과 댓글 수를 조회하기 위한 DTO 구현
-[x] PostQueryRepository의 JDBC 구현체 생성
-[x] 게시글 목록을 조회하기 위한 애플리케이션 서비스 메소드 생성

# 도메인 모델
```mermaid
classDiagram
    class post {
        -id: Long
        -title: String
        -contents: String
        +changeTitle(String title): void
        +changeContents(String contents): void
        +addComment(String commentContents): void
        +attachComment(Long commentId, String commentContents): void
        +updateCommentContents(Long commentId, String contents): void
        +removeComment(Long commentId): void
    }
    class comment{
        -id: Long
        -contents: String
        ~changeContents(String contents): void
    }
    
    post "1"--"*" comment

```