### PR TITLE
Pms/feature/37 id 어노테이션으로 지정

### DIFF
--- a/product-management-system/build.gradle
+++ b/product-management-system/build.gradle
@@ -27,9 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
-    annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/product-management-system/src/main/java/jdbc/productmanagementsystem/application/ProductService.java
+++ b/product-management-system/src/main/java/jdbc/productmanagementsystem/application/ProductService.java
@@ -3,15 +3,17 @@ package jdbc.productmanagementsystem.application;
 import jdbc.productmanagementsystem.domain.exception.ProductNotFoundException;
 import jdbc.productmanagementsystem.domain.model.product.Product;
 import jdbc.productmanagementsystem.domain.repository.ProductRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
-@RequiredArgsConstructor
 public class ProductService {
     private final ProductRepository productRepository;
+
+    public ProductService(ProductRepository productRepository) {
+        this.productRepository = productRepository;
+    }
 
     public Product createProduct(Product product){
         return productRepository.save(product);

--- a/product-management-system/src/main/java/jdbc/productmanagementsystem/domain/model/product/Product.java
+++ b/product-management-system/src/main/java/jdbc/productmanagementsystem/domain/model/product/Product.java
@@ -3,9 +3,7 @@ package jdbc.productmanagementsystem.domain.model.product;
 import jdbc.productmanagementsystem.domain.exception.InvalidPriceException;
 import jdbc.productmanagementsystem.domain.exception.InvalidQuantityException;
 import jdbc.productmanagementsystem.domain.repository.Id;
-import lombok.Getter;
 
-@Getter
 public class Product {
     @Id
     private Long id;
@@ -35,5 +33,21 @@ public class Product {
             throw new InvalidPriceException("가격은 0원 이상이어야 합니다.");
         }
         this.price = newPrice;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    public Long getPrice() {
+        return price;
     }
 }

--- a/product-management-system/src/main/java/jdbc/productmanagementsystem/domain/model/product/Product.java
+++ b/product-management-system/src/main/java/jdbc/productmanagementsystem/domain/model/product/Product.java
@@ -2,10 +2,12 @@ package jdbc.productmanagementsystem.domain.model.product;
 
 import jdbc.productmanagementsystem.domain.exception.InvalidPriceException;
 import jdbc.productmanagementsystem.domain.exception.InvalidQuantityException;
+import jdbc.productmanagementsystem.domain.repository.Id;
 import lombok.Getter;
 
 @Getter
 public class Product {
+    @Id
     private Long id;
     private String productName;
     private Long quantity;

--- a/product-management-system/src/main/java/jdbc/productmanagementsystem/domain/repository/Id.java
+++ b/product-management-system/src/main/java/jdbc/productmanagementsystem/domain/repository/Id.java
@@ -1,0 +1,11 @@
+package jdbc.productmanagementsystem.domain.repository;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Id {
+}

--- a/product-management-system/src/main/java/jdbc/productmanagementsystem/infra/persistence/ProductRepositoryJDBC.java
+++ b/product-management-system/src/main/java/jdbc/productmanagementsystem/infra/persistence/ProductRepositoryJDBC.java
@@ -4,7 +4,6 @@ import jdbc.productmanagementsystem.domain.exception.ProductNotFoundException;
 import jdbc.productmanagementsystem.domain.model.product.Product;
 import jdbc.productmanagementsystem.domain.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -15,12 +14,9 @@ import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
 import java.lang.reflect.Field;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
+
+import static jdbc.productmanagementsystem.infra.persistence.RepositoryJDBCUtils.fillId;
 
 @Repository
 @RequiredArgsConstructor
@@ -38,10 +34,10 @@ public class ProductRepositoryJDBC implements ProductRepository {
 
     @Override
     public Optional<Product> findById(Long id) {
-        try{
+        try {
             Product product = template.queryForObject("select * from product where id = :id", Map.of("id", id), getProductRowMapper());
             return Optional.ofNullable(product);
-        }catch (IncorrectResultSizeDataAccessException e){
+        } catch (IncorrectResultSizeDataAccessException e) {
             return Optional.empty();
         }
     }
@@ -62,7 +58,7 @@ public class ProductRepositoryJDBC implements ProductRepository {
     private Product merge(Product product) {
         SqlParameterSource sqlParameterSource = getSqlParameterSource(product);
         int updated = template.update("update product set product_name = :productName, price = :price, quantity = :quantity where id = :id", sqlParameterSource);
-        if(updated == 0){
+        if (updated == 0) {
             throw new ProductNotFoundException("Product not found");
         }
         return product;
@@ -73,20 +69,14 @@ public class ProductRepositoryJDBC implements ProductRepository {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         String sql = "insert into product (product_name, price, quantity) values (:productName, :price, :quantity)";
         template.update(sql, sqlParameterSource, keyHolder);
-        fillProductId(product, keyHolder);
+        fillId(product, keyHolder.getKey().longValue());
         return product;
     }
 
     private static RowMapper<Product> getProductRowMapper() {
         return (rs, rowNum) -> {
             Product product = new Product(rs.getString("product_name"), rs.getLong("quantity"), rs.getLong("price"));
-            try {
-                Field id1 = Product.class.getDeclaredField("id");
-                id1.setAccessible(true);
-                id1.set(product, rs.getLong("id"));
-            } catch (NoSuchFieldException | IllegalAccessException e) {
-                throw new RuntimeException(e);
-            }
+            fillId(product, rs.getLong("id"));
             return product;
         };
     }
@@ -97,15 +87,5 @@ public class ProductRepositoryJDBC implements ProductRepository {
                 .addValue("productName", product.getProductName())
                 .addValue("price", product.getPrice())
                 .addValue("quantity", product.getQuantity());
-    }
-
-    private static void fillProductId(Product product, KeyHolder keyHolder) {
-        try {
-            Field id = Product.class.getDeclaredField("id");
-            id.setAccessible(true);
-            id.set(product, Objects.requireNonNull(keyHolder.getKey()).longValue());
-        } catch (NoSuchFieldException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/product-management-system/src/main/java/jdbc/productmanagementsystem/infra/persistence/ProductRepositoryJDBC.java
+++ b/product-management-system/src/main/java/jdbc/productmanagementsystem/infra/persistence/ProductRepositoryJDBC.java
@@ -3,7 +3,6 @@ package jdbc.productmanagementsystem.infra.persistence;
 import jdbc.productmanagementsystem.domain.exception.ProductNotFoundException;
 import jdbc.productmanagementsystem.domain.model.product.Product;
 import jdbc.productmanagementsystem.domain.repository.ProductRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.dao.IncorrectResultSizeDataAccessException;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -13,16 +12,20 @@ import org.springframework.jdbc.support.GeneratedKeyHolder;
 import org.springframework.jdbc.support.KeyHolder;
 import org.springframework.stereotype.Repository;
 
-import java.lang.reflect.Field;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 import static jdbc.productmanagementsystem.infra.persistence.RepositoryJDBCUtils.fillId;
 
 @Repository
-@RequiredArgsConstructor
 public class ProductRepositoryJDBC implements ProductRepository {
 
     private final NamedParameterJdbcTemplate template;
+
+    public ProductRepositoryJDBC(NamedParameterJdbcTemplate template) {
+        this.template = template;
+    }
 
     @Override
     public Product save(Product product) {

--- a/product-management-system/src/main/java/jdbc/productmanagementsystem/infra/persistence/RepositoryJDBCUtils.java
+++ b/product-management-system/src/main/java/jdbc/productmanagementsystem/infra/persistence/RepositoryJDBCUtils.java
@@ -1,0 +1,29 @@
+package jdbc.productmanagementsystem.infra.persistence;
+
+import jdbc.productmanagementsystem.domain.model.product.Product;
+import jdbc.productmanagementsystem.domain.repository.Id;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class RepositoryJDBCUtils {
+    static void fillId(Object object, long idValue) {
+        try {
+            Optional<Field> idField = findIdField();
+            if (idField.isEmpty()) return;
+            Field id = idField.get();
+            id.setAccessible(true);
+            id.set(object, idValue);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Optional<Field> findIdField() {
+        Field[] declaredFields = Product.class.getDeclaredFields();
+        return Arrays.stream(declaredFields)
+                .filter(field -> field.isAnnotationPresent(Id.class))
+                .findFirst();
+    }
+}

--- a/product-management-system/src/main/java/jdbc/productmanagementsystem/interfaces/product/ProductController.java
+++ b/product-management-system/src/main/java/jdbc/productmanagementsystem/interfaces/product/ProductController.java
@@ -3,7 +3,6 @@ package jdbc.productmanagementsystem.interfaces.product;
 import jdbc.productmanagementsystem.application.ProductService;
 import jdbc.productmanagementsystem.domain.model.product.Product;
 import jdbc.productmanagementsystem.interfaces.product.dto.ProductDTO;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -11,9 +10,12 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @Controller
-@RequiredArgsConstructor
 public class ProductController {
     private final ProductService productService;
+
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
 
     @GetMapping("/")
     public String home(Model model) {

--- a/product-management-system/src/main/java/jdbc/productmanagementsystem/interfaces/product/dto/ProductDTO.java
+++ b/product-management-system/src/main/java/jdbc/productmanagementsystem/interfaces/product/dto/ProductDTO.java
@@ -1,15 +1,35 @@
 package jdbc.productmanagementsystem.interfaces.product.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
-
-@Getter
-@Setter
-@AllArgsConstructor
 public class ProductDTO {
     private Long id;
     private String productName;
     private Long quantity;
     private Long price;
+
+    public ProductDTO(Long id, String productName, Long quantity, Long price) {
+        this.id = id;
+        this.productName = productName;
+        this.quantity = quantity;
+        this.price = price;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
 }

--- a/product-management-system/src/test/java/jdbc/productmanagementsystem/domain/model/product/ProductTest.java
+++ b/product-management-system/src/test/java/jdbc/productmanagementsystem/domain/model/product/ProductTest.java
@@ -1,0 +1,34 @@
+package jdbc.productmanagementsystem.domain.model.product;
+
+import org.junit.jupiter.api.Test;
+
+class ProductTest {
+
+    @Test
+    void changeName() {
+    }
+
+    @Test
+    void changeQuantity() {
+    }
+
+    @Test
+    void changePrice() {
+    }
+
+    @Test
+    void getId() {
+    }
+
+    @Test
+    void getProductName() {
+    }
+
+    @Test
+    void getQuantity() {
+    }
+
+    @Test
+    void getPrice() {
+    }
+}


### PR DESCRIPTION
# 관련 이슈
close #37 

# 변경된 점
- [x] ID 에 대한 정보를 어노테이션으로 지정하도록 변경
  - 판단 근거 
    - id - DDD에서 엔티티가 될 수 있는 기준(식별자, 상태, 기능 중 식별자 담당)
    - 그러므로 ID가 도메인 레이어에 들어갈 자격이 있다고 판단
- [x] Lombok 의존성 제거
# 도메인 모델
```mermaid
classDiagram
	class Product{
		-id: int
		-productName: String
		-quantity: int
		-price: int
		+changeQuantity(int): void
		+changeName(String): void
		+changePrice(int): void
	}
```

# 패키지 구조
```text
.
└── jdbc
    └── productmanagementsystem
        ├── ProductManagementSystemApplication.java
        ├── application
        │   └── ProductService.java
        ├── domain
        │   ├── exception
        │   │   ├── InvalidPriceException.java
        │   │   ├── InvalidQuantityException.java
        │   │   └── ProductNotFoundException.java
        │   ├── model
        │   │   └── product
        │   │       └── Product.java
        │   └── repository
        │       ├── Id.java
        │       └── ProductRepository.java
        ├── infra
        │   └── persistence
        │       ├── ProductRepositoryJDBC.java
        │       └── RepositoryJDBCUtils.java
        └── interfaces
            └── product
                ├── ProductController.java
                └── dto
                    └── ProductDTO.java

```
